### PR TITLE
Add draft ADR for no unordered arrays

### DIFF
--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -1,5 +1,35 @@
 # Architectural Decision Record
 
+## 2021-09-22 - Order will be recognized by digesting arrays in the given order, and no unordered digests will be provided
+
+### Decision
+
+The final sequence collection digests will reflect the order by digesting the arrays in the order provided. We will employ no additional 'order' array, and no additional unordered digests in the string-to-digest. To determine whether two sequence collections differ only in order will require either 1) using the compatibility testing API; or 2) implementing an additional functionality for unordered digests on top of the basic sequence collections specification.
+
+### Rationale
+
+Our earlier decision determined that order *must* be reflected in the sequence digests, but did not determine the way to ensure that. After months of debate we came up with 3 competing ideas that could do this:
+
+A. Digest arrays in given order. 
+
+B. Reorder all given arrays according to a single canonical order, and encode order in a separate 'order' array that provides an index into the canonically ordered arrays.
+
+C. Reorder each given array individually, and then provide a separate 'order_ATTR' array as an index for each array.
+
+D. Store each array in both ordered and unordered form.
+
+After lots of initial enthusiasm for option B, we determined that it fails to deliver on the promise of staying invariant when order changes, because if there is a change in any array on which the canonical order is based, this changes the canonical ordering, which in turn changes all the array digests. So these 'unordered' (or canonically ordered) digests are in fact not fit for their main purpose. We therefore agreed to discard this option.
+
+While options C/D skirt this issue by having a separate order for each array, so that changes in one array do not affect the digest of another, they add significant complexity as everything needs to be stored twice.
+
+To conclude, option A seems simple and straightforward, satisfies for a basic implementation. We thus defer the question of determining whether two sequence collections differ only in order to the compatibility API.
+
+### Known limitations
+
+For use cases that require determination of whether two sequence collections differ only in element order, option A will not provide an answer based on digest comparison alone. Instead, the query will be required to use the compatibility API, which means retrieving the contents of the array to compare them.
+
+Therefore, to answer this 'order-equivalence' question will require a bit more work than if unordered digests were available; however, this functionality can be easily implemented on top of the basic functionality in a number of ways. And at the end of the day, the compatibility function is not particularly onerous of a calculation anyway.
+
 ## 2021-08-25 - Sequence collection digests will reflect sequence order
 
 ### Decision


### PR DESCRIPTION
Explains rationale for decision to follow "option A" for how to encode order in the digests.