### PR TITLE
Add ADR for serialisation of sequence collection

### DIFF
--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -26,7 +26,7 @@ For example the length array at level 2:
 [248956422, 242193529, 198295559]
 ```
 
-Will have its element converted to strings and be serialised using RFC-8785 and digested as a binary string. Here the output of the python implementation: 
+Will be serialised using RFC-8785 and digested as a binary string. Here the output of the python implementation: 
 
 ```python
 b'[248956422,242193529,198295559]'
@@ -62,9 +62,9 @@ An object is created with the array name as properties and the digest as value.
 Example the following collection: 
 ```json
 {
-    "sequences": "EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe",
-    "lengths": "5K4odB173rjao1Cnbk5BnvLt9V7aPAa2",
-    "names": "g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp"
+    "sequences": "ga4gh:sequences.EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe",
+    "lengths": "ga4gh:lengths.5K4odB173rjao1Cnbk5BnvLt9V7aPAa2",
+    "names": "ga4gh:names.g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp"
 }
 ```
 
@@ -72,7 +72,7 @@ Example the following collection:
 This will create a canonical representation of the object 
 
 ```python
-b'{"lengths":"5K4odB173rjao1Cnbk5BnvLt9V7aPAa2","names":"g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp","sequences":"EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe"}'
+b'{"lengths":"ga4gh:lengths.5K4odB173rjao1Cnbk5BnvLt9V7aPAa2","names":"ga4gh:names.g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp","sequences":"ga4gh:sequences.EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe"}'
 ```
 
 #### 5. Digest the final canonical representation

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -47,8 +47,8 @@ b'["\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x93-1","\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x9
 
 The canonical string representation is then digested. Assuming the use of GA4GH (sha512 trim to 24) digest, the following array of length
 
-```json
-b"[248956422,242193529,198295559]"
+```python
+b'[248956422,242193529,198295559]'
 ```
 
 would be converted

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -48,13 +48,13 @@ b'["\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x93-1","\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x9
 The canonical string representation is then digested. Assuming the use of GA4GH (sha512 trim to 24) digest, the following array of length
 
 ```json
-b'[248956422,242193529,198295559]'
+b"[248956422,242193529,198295559]"
 ```
 
 would be converted
 
 ```json
-'5K4odB173rjao1Cnbk5BnvLt9V7aPAa2'
+"5K4odB173rjao1Cnbk5BnvLt9V7aPAa2"
 ```
 
 #### 3. Creation of an object composed of the array names and the digested arrays

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -9,6 +9,8 @@
 
 ## 2022-09-05 - How sequence collection are serialized prior to digestion
 
+The serialisation in this context is the conversion of the sequence collection object into a string that can be digested.
+
 ### Decision
 
 The serialisation of a sequence collection will use the following steps
@@ -86,7 +88,7 @@ Finally the canonical, representation is digested again to produce the identifie
 ### Rationale
 The decision to use the serialisation of array and object provided in RFC-8785 allows sequence collection to support any type of characters and rely on a documented standard that offer implementation in multiple languages.
 It also future-proofs the serialisation method if we ever allow complex object to be element of the array.
-
+ 
 ### Linked issues
 
  - [https://github.com/ga4gh/seqcol-spec/issues/1](https://github.com/ga4gh/seqcol-spec/issues/1)
@@ -96,7 +98,7 @@ It also future-proofs the serialisation method if we ever allow complex object t
 
 ### Known limitations
 
-The JSON canonical serialisation defined in RFC-8785 has a limited set of reference implementation. It is possible that its implementation might make sequence collection implementation more difficult in other languages.  
+The JSON canonical serialisation defined in RFC-8785 has a limited set of reference implementation. It is possible that its implementation makes sequence collection implementation more difficult in languages where the RFC is not implemented. In this cases it is valuable to note that the current specification of Sequence Collection do not require that all the features of RFC-8785 be implemented. 
 
 ## 2022-10-05 - Terminology decisions
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -19,11 +19,10 @@ The serialisation of a sequence collection will use the following steps
  5. Digest the final canonical representation
 
 
-#### For converting from level 2 to level 1
+#### 1. Apply RFC-8785 for converting from level 2 to level 1
 
-Each array is converted into a canonical string representation.
 For example the length array at level 2:
-```
+```json
 [248956422, 242193529, 198295559]
 ```
 
@@ -33,10 +32,8 @@ Will have its element converted to strings and be serialised using RFC-8785 and 
 b'[248956422,242193529,198295559]'
 ```
 
-And subsequently digested.
-
 It would also support any UTF-8 character. For example this array of names
-```
+```json
 ["染色体-1","染色体-2","染色体-3"]
 ```
 
@@ -46,21 +43,43 @@ Would create the following serialisation:
 b'["\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x93-1","\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x93-2","\xe6\x9f\x93\xe8\x89\xb2\xe4\xbd\x93-3"]'
 ```
 
-#### Conversion from level 1 to level 0
-An object is created with the array name as properties and the digest as value.
-For Example the collection at level 1: 
+#### 2. Digest of the canonical representation
+
+The canonical string representation is then digested. Assuming the use of GA4GH (sha512 trim to 24) digest, the following array of length
+
+```json
+b'[248956422,242193529,198295559]'
 ```
+
+would be converted
+
+```json
+'5K4odB173rjao1Cnbk5BnvLt9V7aPAa2'
+```
+
+#### 3. Creation of an object composed of the array names and the digested arrays
+An object is created with the array name as properties and the digest as value.
+Example the following collection: 
+```json
 {
-    'sequences': '8dd93796fa0225e92eb159a8779f1b254776557f748f8bfb',
-    'lengths': '501fd98e2fdcc276c47306bd72c9155489ed2b23123ddfa2',
-    'names': '7bc90a07cf25f2f64f33baee3d420ad1ae5f442055280d43',
+    "sequences": "EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe",
+    "lengths": "5K4odB173rjao1Cnbk5BnvLt9V7aPAa2",
+    "names": "g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp"
 }
 ```
 
-Is serialised as: 
+#### 4. Use RFC-8785 on the object
+This will create a canonical representation of the object 
 
+```python
+b'{"lengths":"5K4odB173rjao1Cnbk5BnvLt9V7aPAa2","names":"g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp","sequences":"EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe"}'
 ```
-b'{"lengths":"501fd98e2fdcc276c47306bd72c9155489ed2b23123ddfa2","names":"7bc90a07cf25f2f64f33baee3d420ad1ae5f442055280d43","sequences":"8dd93796fa0225e92eb159a8779f1b254776557f748f8bfb"}'
+
+#### 5. Digest the final canonical representation
+Finally the canonical, representation is digested again to produce the identifier
+
+```json
+"S3LCyI788LE6vq89Tc_LojEcsMZRixzP"
 ```
 
 ### Rationale

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -12,12 +12,11 @@
 
 The serialisation of a sequence collection will use the following steps
 
- 1. Convert all elements of level 2 arrays into UTF-8 string
- 2. Apply RFC-8785 on each array of level 2
- 3. Digest each the canonical representation of each array
- 4. Create object representation of the seq-col using array names and digested arrays
- 5. Apply RFC-8785 on the object representation
- 6. Digest the final canonical representation
+ 1. Apply RFC-8785 on each array of level 2
+ 2. Digest each the canonical representation of each array
+ 3. Create object representation of the seq-col using array names and digested arrays
+ 4. Apply RFC-8785 on the object representation
+ 5. Digest the final canonical representation
 
 
 #### For converting from level 2 to level 1
@@ -31,7 +30,7 @@ For example the length array at level 2:
 Will have its element converted to strings and be serialised using RFC-8785 and digested as a binary string. Here the output of the python implementation: 
 
 ```python
-b'["248956422","242193529","198295559"]'
+b'[248956422,242193529,198295559]'
 ```
 
 And subsequently digested.
@@ -73,10 +72,12 @@ It also future-proofs the serialisation method if we ever allow complex object t
 
  - [https://github.com/ga4gh/seqcol-spec/issues/1](https://github.com/ga4gh/seqcol-spec/issues/1)
  - [https://github.com/ga4gh/seqcol-spec/issues/25](https://github.com/ga4gh/seqcol-spec/issues/25)
+ - [https://github.com/ga4gh/seqcol-spec/issues/33](https://github.com/ga4gh/seqcol-spec/issues/33)
+
 
 ### Known limitations
 
-The JSON cannonical serialisation defined in RFC-8785 has a limited set of reference implementation. It is possible that its implementation might make sequence collection implementation more difficult in other languages.  
+The JSON canonical serialisation defined in RFC-8785 has a limited set of reference implementation. It is possible that its implementation might make sequence collection implementation more difficult in other languages.  
 
 ## 2022-06-15 - Structure for the return value of the comparison API endpoint
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -64,7 +64,6 @@ b'{"lengths":"501fd98e2fdcc276c47306bd72c9155489ed2b23123ddfa2","names":"7bc90a0
 ```
 
 ### Rationale
-Enforcing that all elements of the level 2 arrays would be converted to string ensure all implementation treat them similarly regardless of the original types.
 The decision to use the serialisation of array and object provided in RFC-8785 allows sequence collection to support any type of characters and rely on a documented standard that offer implementation in multiple languages.
 It also future-proofs the serialisation method if we ever allow complex object to be element of the array.
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -6,7 +6,7 @@
 
 [TOC]
 
-## 2022-07-05 - How sequence collection are serialized prior to digestion
+## 2022-09-05 - How sequence collection are serialized prior to digestion
 
 ### Decision
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -62,9 +62,9 @@ An object is created with the array name as properties and the digest as value.
 Example the following collection: 
 ```json
 {
-    "sequences": "ga4gh:sequences.EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe",
-    "lengths": "ga4gh:lengths.5K4odB173rjao1Cnbk5BnvLt9V7aPAa2",
-    "names": "ga4gh:names.g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp"
+    "sequences": "EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe",
+    "lengths": "5K4odB173rjao1Cnbk5BnvLt9V7aPAa2",
+    "names": "g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp"
 }
 ```
 
@@ -72,7 +72,7 @@ Example the following collection:
 This will create a canonical representation of the object 
 
 ```python
-b'{"lengths":"ga4gh:lengths.5K4odB173rjao1Cnbk5BnvLt9V7aPAa2","names":"ga4gh:names.g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp","sequences":"ga4gh:sequences.EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe"}'
+b'{"lengths":"5K4odB173rjao1Cnbk5BnvLt9V7aPAa2","names":"g04lKdxiYtG3dOGeUC5AdKEifw65G0Wp","sequences":"EiYgJtUfGyad7wf5atL5OG4Fkzohp2qe"}'
 ```
 
 #### 5. Digest the final canonical representation

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -13,7 +13,7 @@
 The serialisation of a sequence collection will use the following steps
 
  1. Apply RFC-8785 on each array of level 2
- 2. Digest each the canonical representation of each array
+ 2. Digest the canonical representation of each array
  3. Create object representation of the seq-col using array names and digested arrays
  4. Apply RFC-8785 on the object representation
  5. Digest the final canonical representation
@@ -51,7 +51,7 @@ The canonical string representation is then digested. Assuming the use of GA4GH 
 b'[248956422,242193529,198295559]'
 ```
 
-would be converted
+would be converted to 
 
 ```json
 "5K4odB173rjao1Cnbk5BnvLt9V7aPAa2"


### PR DESCRIPTION
This PR now describe the serialisation that sequence collection should go through before the digest algorithm should be applied based on @sveinugu suggestion.
This should address #1 and #33 