### PR TITLE
Add ADR for: Internal identifiers SHOULD NOT be prefixed

### DIFF
--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -16,11 +16,13 @@ In some situations, identifiers are prefixed. For example, these may be CURIEs, 
 
 ### Decision
 
-We determined that *internally*, we will not append prefixes to the strings we are going to digest. If a particular identifier defines some kind of a namespace as part of the identifier (*e.g.* a refget sequence identifier), then it's of course no problem, we take that identifier at face value. To summarize:
+We determined that *internally*, we will not append prefixes to the strings we are going to digest. However, if a particular identifier defines some kind of a prefix *as part of the identifier* (*e.g.* a refget sequence identifier), then it's of course no problem, we take that identifier at face value. To summarize:
 
 - for internal identifiers (those generated within seqcol), we digest only digests, not prefixes of any kind
 - for external identifiers (like refget identifiers), we accept them at face value, so we wouldn't remove a prefix if you declare it is was part of your sequence identifier
 - the seqcol specification should RECOMMEND using refget identifiers
+
+More specifically, for refget, there are two types of prefix: the namespace prefix (`ga4gh:`) and type type prefix (`SQ.`). Right now, the refget server requires you to have the type prefix to request a lookup; the refget protocol declares that this type prefix is *part of the identifier*. However, the `ga4gh:` prefix is more of a namespace prefix and is *not* required, and therefore not considered part of the identifier. Therefore, the seqcol `sequence` values would *include* the `SQ.` but not the `ga4gh:`.
 
 ### Rationale
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -23,7 +23,7 @@ We determined that *internally*, we will not append prefixes to the strings we a
 
 According to the definition of CURIEs:
 
-    A host language MAY declare a default prefix value, or MAY provide a mechanism for defining a def
+    A host language MAY declare a default prefix value, or MAY provide a mechanism for defining a defining a default prefix value. In such a host language, when the prefix is omitted from a CURIE, the default prefix value MUST be used.
 
 We see no need to add prefixes to the identifiers we use internally, which we just assume belong to our namespace. Adding prefixes will complicate things and does not add benefits. Prefixes may be added to our identifiers by outside entities as needed to define for them the scope of our local digests.
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -6,6 +6,31 @@
 
 [TOC]
 
+## 2023-01-25 - No internal prefixes
+
+### Background
+
+In some situations, identifiers are prefixed. For example, these may be CURIEs, which specify namespaces or provide other information about what the identifier represents. This raises questions about when and where we should expect or use prefixes. This has to be determined because including prefixes in the content that gets digested changes it, so we have to be consistent.
+
+### Decision
+
+We determined that *internally*, we will not append prefixes to the strings we are going to digest. If a particular identifier defines some kind of a namespace as part of the identifier (*e.g.* a refget sequence identifier), then it's of course no problem, we take that identifier at face value. To summarize:
+
+- for internal identifiers (those generated within seqcol), we digest only digests, not prefixes of any kind
+- for external identifiers (like refget identifiers), we accept them at face value, so we wouldn't remove a prefix if you declare it is was part of your sequence identifier
+
+### Rationale
+
+According to the definition of CURIEs:
+
+    A host language MAY declare a default prefix value, or MAY provide a mechanism for defining a def
+
+We see no need to add prefixes to the identifiers we use internally, which we just assume belong to our namespace. Adding prefixes will complicate things and does not add benefits. Prefixes may be added to our identifiers by outside entities as needed to define for them the scope of our local digests.
+
+### Linked issues
+
+- https://github.com/ga4gh/seqcol-spec/issues/37
+
 ## 2022-10-05 - Terminology decisions
 
 ### Decision

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -6,7 +6,7 @@
 
 [TOC]
 
-## 2023-01-25 - No internal prefixes
+## 2023-01-25 - Internal identifiers SHOULD NOT be prefixed
 
 ### Background
 

--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -6,7 +6,7 @@
 
 [TOC]
 
-## 2023-01-25 - Internal identifiers SHOULD NOT be prefixed
+## 2023-06-14 - Internal identifiers SHOULD NOT be prefixed
 
 ### Background
 
@@ -18,6 +18,7 @@ We determined that *internally*, we will not append prefixes to the strings we a
 
 - for internal identifiers (those generated within seqcol), we digest only digests, not prefixes of any kind
 - for external identifiers (like refget identifiers), we accept them at face value, so we wouldn't remove a prefix if you declare it is was part of your sequence identifier
+- the seqcol specification should RECOMMEND using refget identifiers
 
 ### Rationale
 


### PR DESCRIPTION
Resolves half of #37