### PR TITLE
Add ADR for no ui prefixes

### DIFF
--- a/docs/decision_record.md
+++ b/docs/decision_record.md
@@ -8,8 +8,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 [TOC]
 
+## 2023-08-25 The user-facing API will neither expect to provide prefixes
 
+## Rationale
 
+We have debated whether the digests returned by the API should be prefixed in any way (either a namespace-type prefix, or a type prefix). We have also debated whether the API should *accept* prefixed versions of digests. We decided (for now) that neither should be true; our protocol is simply to use and provide the seqcol digests straight up. We view the prefixes as being something useful for an external context to determine where a digest came from or belongs; but this seems external to how our service should behave internally. Therefore, any sort of prefix should be happening by whatever is *using* this service, not by the service itself. For example, a ga4gh-wide broker that could disambiguate between different types of digests may require an incoming digest to have a type prefix, but this would be governed by such a context-oriented service, not by the seqcol service itself.
+
+In the future, when it becomes more clear how this service will fit in with other services in the ga4gh ecosystem, we could revisit this decision.
 
 ## 2023-07-26 There will be no metadata endpoint
 


### PR DESCRIPTION
This summarizes our decision that the user-facing API will neither expect to provide prefixes (for now).